### PR TITLE
Improve support for JSON parameters

### DIFF
--- a/flask_restplus_patched/namespace.py
+++ b/flask_restplus_patched/namespace.py
@@ -70,6 +70,8 @@ class Namespace(OriginalNamespace):
                 _locations = ('json', )
             else:
                 _locations = locations
+            if locations is not None:
+                parameters.context['in'] = locations
 
             return self.doc(params=parameters)(
                 self.response(code=http_exceptions.UnprocessableEntity.code)(

--- a/flask_restplus_patched/swagger.py
+++ b/flask_restplus_patched/swagger.py
@@ -14,7 +14,7 @@ class Swagger(OriginalSwagger):
         if isinstance(schema, dict) and all(isinstance(field, dict) for field in schema.values()):
             return list(schema.values())
 
-        if schema.many:
+        if schema.many or 'in' in schema.context and 'json' in schema.context['in']:
             default_location = 'body'
         else:
             default_location = 'query'


### PR DESCRIPTION
When using api.parameters decorator, the locations parameter is now taken into account to generate the documentation ("@api.parameters(parameters.MyParameters(many=False), locations=('json',))".