### PR TITLE
Add missing default response (HTTP/204) for DELETE handlers

### DIFF
--- a/app/modules/teams/resources.py
+++ b/app/modules/teams/resources.py
@@ -8,6 +8,7 @@ RESTful API Team resources
 import logging
 
 from flask_restplus import Resource
+from flask_restplus_patched._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace, abort, http_exceptions
@@ -15,12 +16,13 @@ from app.extensions.api.parameters import PaginationParameters
 from app.modules.users import permissions
 from app.modules.users.models import User
 
+
 from . import parameters, schemas
 from .models import Team, TeamMember
 
 
-log = logging.getLogger(__name__) # pylint: disable=invalid-name
-api = Namespace('teams', description="Teams") # pylint: disable=invalid-name
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+api = Namespace('teams', description="Teams")  # pylint: disable=invalid-name
 
 
 @api.route('/')
@@ -111,6 +113,7 @@ class TeamByID(Resource):
     )
     @api.permission_required(permissions.WriteAccessPermission())
     @api.response(code=http_exceptions.Conflict.code)
+    @api.response(code=HTTPStatus.NO_CONTENT)
     def delete(self, team):
         """
         Delete a team by ID.

--- a/flask_restplus_patched/_http.py
+++ b/flask_restplus_patched/_http.py
@@ -1,0 +1,5 @@
+try:
+    from http import HTTPStatus
+except ImportError:
+    class HTTPStatus:
+        NO_CONTENT = 204

--- a/tests/modules/teams/resources/test_modifying_teams.py
+++ b/tests/modules/teams/resources/test_modifying_teams.py
@@ -133,7 +133,7 @@ def test_team_deletion(flask_app_client, regular_user, team_for_regular_user):
             '/api/v1/teams/%d' % team_for_regular_user.id
         )
 
-    assert response.status_code == 200
+    assert response.status_code == 204
     assert response.content_type == 'application/json'
 
 


### PR DESCRIPTION
Closes #26: Add missing default response (HTTP/204) for DELETE handlers
Refactor response decorator in namespace of flasл_resplus_patched
Add response(code=204) to delete in teams/resources.py
Updated team delete test to expect 204 status instead of 200

I will provide constant for 204-code in one of future commit if you don't mind. Any of packages haven't what you want. We have to create our own constants.