### PR TITLE
Pre-flight OPTIONS requests handler

### DIFF
--- a/tests/modules/teams/resources/test_options.py
+++ b/tests/modules/teams/resources/test_options.py
@@ -29,3 +29,18 @@ def test_teams_options_authorized(
 
     assert response.status_code == 204
     assert set(response.headers['Allow'].split(', ')) == expected_allowed_methods
+
+
+@pytest.mark.parametrize('http_path,expected_allowed_methods', (
+    ('/api/v1/teams/', {'GET', 'POST', 'OPTIONS'}),
+))
+def test_preflight_options_request(http_path, expected_allowed_methods, flask_app_client):
+    response = flask_app_client.open(
+        method='OPTIONS',
+        path=http_path,
+        headers={'Access-Control-Request-Method': 'post'}
+    )
+    assert response.status_code == 200
+    assert set(
+        response.headers['Access-Control-Allow-Methods'].split(', ')
+    ) == expected_allowed_methods


### PR DESCRIPTION
Add `preflight_options_handler` decorator to `flask_restplus_patchet/namespace.py`. Wrap all `options` in `namespace:route` with a new decorator.

This decorator detects if `OPTIONS` request is pre-flight and always returns status code 200 with `Access-Control-Allow-Methods` header contains all allowed methods.