### PR TITLE
[Invoke task] New module boilerplate

### DIFF
--- a/tasks/app/__init__.py
+++ b/tasks/app/__init__.py
@@ -5,7 +5,7 @@ Application related tasks for Invoke.
 
 from invoke import Collection
 
-from . import dependencies, env, db, run, users, swagger
+from . import dependencies, env, db, run, users, swagger, boilerplates
 
 from config import BaseConfig
 
@@ -16,6 +16,7 @@ namespace = Collection(
     run,
     users,
     swagger,
+    boilerplates,
 )
 
 namespace.configure({

--- a/tasks/app/boilerplates.py
+++ b/tasks/app/boilerplates.py
@@ -1,0 +1,84 @@
+# pylint: disable=line-too-long
+"""
+Boilerplates
+"""
+from __future__ import print_function
+
+import logging
+import os
+import re
+
+from jinja2 import Environment, FileSystemLoader
+
+try:
+    from invoke import ctask as task
+except ImportError:  # Invoke 0.13 renamed ctask to task
+    from invoke import task
+
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+
+@task(default=True)
+def crud_module(context, name='new_module', singular=None):
+    """
+    Create CRUD empty module with `name` (app.boilerplates.crud_module --name=articles --singular=article)
+    """
+    assert re.match('^[a-zA-Z0-9_]+$', name)
+
+    if not singular:
+        singular = name[:-1]
+
+    module_path = 'app/modules/%s' % name
+
+    module_title = " ".join(
+        [word.capitalize()
+            for word in name.split('_')
+        ]
+    )
+
+    model_name = "".join(
+        [word.capitalize()
+            for word in singular.split('_')
+        ]
+    )
+
+    if os.path.exists(module_path):
+        log.critical('Module `%s` already exists.' % name)
+        return
+
+    os.makedirs(module_path)
+
+    env = Environment(
+        loader=FileSystemLoader('tasks/app/boilerplates_templates/crud_module')
+    )
+    for template_file in (
+        '__init__',
+        'models',
+        'parameters',
+        'resources',
+        'schemas',
+    ):
+        template = env.get_template('%s.py.template' % template_file)
+        template.stream(
+            module_title=module_title,
+            model_name=model_name,
+            module_name=name,
+            module_name_singular=singular if singular else name
+        ).dump(
+            '%s/%s.py' % (module_path, template_file)
+        )
+
+    log.info("Module `%s` has been created.", name)
+    print(
+        "Add `%(module_name)s` to `ENABLED_MODULES` in `config.py`\n"
+        "ENABLED_MODULES = (\n"
+        "\t'auth',\n"
+        "\t'users',\n"
+        "\t'teams',\n"
+        "\t'%(module_name)s',\n\n"
+        "\t'api',\n"
+        ")\n\n"
+        "You can find your module at `app/modules/` directory"
+        % {'module_name': name}
+    )

--- a/tasks/app/boilerplates_templates/crud_module/__init__.py.template
+++ b/tasks/app/boilerplates_templates/crud_module/__init__.py.template
@@ -1,0 +1,21 @@
+# encoding: utf-8
+"""
+{{ module_title }} module
+============
+"""
+
+from app.extensions.api import api_v1
+
+
+def init_app(app, **kwargs):
+    # pylint: disable=unused-argument,unused-variable
+    """
+    Init {{ module_title }} module.
+    """
+    api_v1.add_oauth_scope('{{ module_name }}:read', "Provide access to {{ module_title }} details")
+    api_v1.add_oauth_scope('{{ module_name }}:write', "Provide write access to {{ module_title }} details")
+
+    # Touch underlying modules
+    from . import models, resources
+
+    api_v1.add_namespace(resources.api)

--- a/tasks/app/boilerplates_templates/crud_module/models.py.template
+++ b/tasks/app/boilerplates_templates/crud_module/models.py.template
@@ -1,0 +1,35 @@
+# encoding: utf-8
+"""
+{{ module_title }} database models
+--------------------
+"""
+
+from sqlalchemy_utils import Timestamp
+
+from app.extensions import db
+
+
+class {{ model_name }}(db.Model, Timestamp):
+    """
+    {{ module_title }} database model.
+    """
+
+    id = db.Column(db.Integer, primary_key=True) # pylint: disable=invalid-name
+    title = db.Column(db.String(length=50), nullable=False)
+
+    def __repr__(self):
+        return (
+            "<{class_name}("
+            "id={self.id}, "
+            "title=\"{self.title}\""
+            ")>".format(
+                class_name=self.__class__.__name__,
+                self=self
+            )
+        )
+
+    @db.validates('title')
+    def validate_title(self, key, title): # pylint: disable=unused-argument,no-self-use
+        if len(title) < 3:
+            raise ValueError("Title has to be at least 3 characters long.")
+        return title

--- a/tasks/app/boilerplates_templates/crud_module/parameters.py.template
+++ b/tasks/app/boilerplates_templates/crud_module/parameters.py.template
@@ -1,0 +1,30 @@
+# encoding: utf-8
+"""
+Input arguments (Parameters) for {{ module_name|title }} resources RESTful API
+-----------------------------------------------------------
+"""
+
+from flask_marshmallow import base_fields
+from flask_restplus_patched import PostFormParameters, PatchJSONParameters
+
+from . import schemas
+from .models import {{ model_name }}
+
+
+class Create{{ model_name }}Parameters(PostFormParameters, schemas.Base{{ model_name }}Schema):
+
+    class Meta(schemas.Base{{ model_name }}Schema.Meta):
+        pass
+
+
+class Patch{{ model_name }}DetailsParameters(PatchJSONParameters):
+    # pylint: disable=abstract-method,missing-docstring
+    OPERATION_CHOICES = (
+        PatchJSONParameters.OP_REPLACE,
+    )
+
+    PATH_CHOICES = tuple(
+        '/%s' % field for field in (
+            {{ model_name }}.title.key,
+        )
+    )

--- a/tasks/app/boilerplates_templates/crud_module/resources.py.template
+++ b/tasks/app/boilerplates_templates/crud_module/resources.py.template
@@ -1,0 +1,112 @@
+# encoding: utf-8
+# pylint: disable=bad-continuation
+"""
+RESTful API {{ module_title }} resources
+--------------------------
+"""
+
+import logging
+
+from flask_login import current_user
+from flask_restplus_patched import Resource
+from flask_restplus_patched._http import HTTPStatus
+
+from app.extensions import db
+from app.extensions.api import Namespace, abort
+from app.extensions.api.parameters import PaginationParameters
+from app.modules.users import permissions
+
+
+from . import parameters, schemas
+from .models import {{ model_name }}
+
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+api = Namespace('{{ module_name }}', description="{{ module_title }}")  # pylint: disable=invalid-name
+
+
+@api.route('/')
+@api.login_required(oauth_scopes=['{{ module_name }}:read'])
+class {{ module_title.replace(' ','') }}(Resource):
+    """
+    Manipulations with {{ module_title }}.
+    """
+
+    @api.parameters(PaginationParameters())
+    @api.response(schemas.Base{{ model_name }}Schema(many=True))
+    def get(self, args):
+        """
+        List of {{ module_name }}.
+
+        Returns a list of {{ module_title }} starting from ``offset`` limited by ``limit``
+        parameter.
+        """
+        return {{ model_name }}.query.offset(args['offset']).limit(args['limit'])
+
+    @api.login_required(oauth_scopes=['{{ module_name }}:write'])
+    @api.parameters(parameters.Create{{ model_name }}Parameters())
+    @api.response(schemas.Detailed{{ model_name }}Schema())
+    @api.response(code=HTTPStatus.CONFLICT)
+    def post(self, args):
+        """
+        Create a new {{ model_name }}.
+        """
+        with api.commit_or_abort(
+                db.session,
+                default_error_message="Failed to create a new {{ module_name_singular }}"
+            ):
+            {{ module_name_singular }} = {{ model_name }}(**args)
+            db.session.add({{ module_name_singular }})
+        return {{ module_name_singular }}
+
+
+@api.route('/<int:{{ module_name_singular }}_id>')
+@api.login_required(oauth_scopes=['{{ module_name }}:read'])
+@api.response(
+    code=HTTPStatus.NOT_FOUND,
+    description="{{ model_name }} not found.",
+)
+@api.resolve_object_by_model({{ model_name }}, '{{ module_name_singular }}')
+class {{ model_name }}ByID(Resource):
+    """
+    Manipulations with a specific {{ model_name }}.
+    """
+
+    @api.response(schemas.Detailed{{ model_name }}Schema())
+    def get(self, {{ module_name_singular }}):
+        """
+        Get {{ model_name }} details by ID.
+        """
+        return {{ module_name_singular }}
+
+    @api.login_required(oauth_scopes=['{{ module_name }}:write'])
+    @api.permission_required(permissions.WriteAccessPermission())
+    @api.parameters(parameters.Patch{{ model_name }}DetailsParameters())
+    @api.response(schemas.Detailed{{ model_name }}Schema())
+    @api.response(code=HTTPStatus.CONFLICT)
+    def patch(self, args, {{ module_name_singular }}):
+        """
+        Patch {{ model_name }} details by ID.
+        """
+        with api.commit_or_abort(
+                db.session,
+                default_error_message="Failed to update {{ model_name }} details."
+            ):
+            parameters.Patch{{ model_name }}DetailsParameters.perform_patch(args, obj={{ module_name_singular }})
+            db.session.merge({{ module_name_singular }})
+        return {{ module_name_singular }}
+
+    @api.login_required(oauth_scopes=['{{ module_name }}:write'])
+    @api.permission_required(permissions.WriteAccessPermission())
+    @api.response(code=HTTPStatus.CONFLICT)
+    @api.response(code=HTTPStatus.NO_CONTENT)
+    def delete(self, {{ module_name_singular }}):
+        """
+        Delete a {{ model_name }} by ID.
+        """
+        with api.commit_or_abort(
+                db.session,
+                default_error_message="Failed to delete the {{ model_name }}."
+            ):
+            db.session.delete({{ module_name_singular }})
+        return None

--- a/tasks/app/boilerplates_templates/crud_module/schemas.py.template
+++ b/tasks/app/boilerplates_templates/crud_module/schemas.py.template
@@ -1,0 +1,39 @@
+# encoding: utf-8
+"""
+Serialization schemas for {{ module_name|title }} resources RESTful API
+----------------------------------------------------
+"""
+
+from flask_marshmallow import base_fields
+from flask_restplus_patched import ModelSchema
+
+from .models import {{ model_name }}
+
+
+class Base{{ model_name }}Schema(ModelSchema):
+    """
+    Base {{ model_name }} schema exposes only the most general fields.
+    """
+
+    class Meta:
+        # pylint: disable=missing-docstring
+        model = {{ model_name }}
+        fields = (
+            {{ model_name }}.id.key,
+            {{ model_name }}.title.key,
+        )
+        dump_only = (
+            {{ model_name }}.id.key,
+        )
+
+
+class Detailed{{ model_name }}Schema(Base{{ model_name }}Schema):
+    """
+    Detailed {{ model_name }} schema exposes all useful fields.
+    """
+
+    class Meta(Base{{ model_name }}Schema.Meta):
+        fields = Base{{ model_name }}Schema.Meta.fields + (
+            {{ model_name }}.created.key,
+            {{ model_name }}.updated.key,
+        )


### PR DESCRIPTION
* Closes #63: [Invoke task] New module boilerplate
* Add `boilerplates` task namespace with `crud_module` task to create simple CRUD module.

Usage is `invoke app.boilerplates --name=articles --singular=article`

Templates for a new module are in `tasks/app/boilerplates_templates/crud_module` in txt format. They are rendering with `Jinja2`, it allows us to avoid additional dependencies.

After CRUD module is created a little reminder appears with info about adding the module to `ENABLED_MODULES` and where to find the sources.