### PR TITLE
Resolve bad usage of SQLA's API

### DIFF
--- a/tasks/app/users.py
+++ b/tasks/app/users.py
@@ -53,7 +53,7 @@ def create_oauth2_client(
     from app.modules.users.models import User
     from app.modules.auth.models import OAuth2Client
 
-    user = User.query.first(User.username == username)
+    user = User.query.filter(User.username == username).first()
     if not user:
         raise Exception("User with username '%s' does not exist." % username)
 


### PR DESCRIPTION
Otherwise I get this error:
```python
Traceback (most recent call last):
  File "/usr/bin/invoke", line 11, in <module>
    sys.exit(program.run())
  File "/usr/lib/python3.5/site-packages/invoke/program.py", line 293, in run
    self.execute()
  File "/usr/lib/python3.5/site-packages/invoke/program.py", line 414, in execute
    executor.execute(*self.tasks)
  File "/usr/lib/python3.5/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/usr/lib/python3.5/site-packages/invoke/tasks.py", line 115, in __call__
    result = self.body(*args, **kwargs)
  File "/opt/www/tasks/app/_utils.py", line 61, in wrapper
    return func(*args, **kwargs)
  File "/opt/www/tasks/app/users.py", line 56, in create_oauth2_client
    user = User.query.first(User.username == username)
TypeError: first() takes 1 positional argument but 2 were given
```

I just tested my patch and it works fine