### PR TITLE
Pass kwargs in Api init_app

### DIFF
--- a/flask_restplus_patched/api.py
+++ b/flask_restplus_patched/api.py
@@ -14,8 +14,8 @@ class Api(OriginalApi):
         # The only purpose of this method is to pass custom Swagger class
         return Swagger(self).as_dict()
 
-    def init_app(self, app):
-        super(Api, self).init_app(app)
+    def init_app(self, app, **kwargs):
+        super(Api, self).init_app(app, **kwargs)
         app.errorhandler(HTTPStatus.UNPROCESSABLE_ENTITY.value)(handle_validation_error)
 
     def namespace(self, *args, **kwargs):


### PR DESCRIPTION
Just porting to `flask-restplus-server-example`, the change that I made in:

https://github.com/Jaza/flask-restplus-patched/commit/7cf658ef1e4eb830939edf9ba55118ae10d44998

The `flask-restplus-patched` `init_app` should accept `**kwargs`, the same as the base `init_app` in `flask-restplus` does, see:

https://github.com/noirbizarre/flask-restplus/blob/0.10.1/flask_restplus/api.py#L148

This allows various params (e.g. `title`, `description`) to be passed in when instantiating the Flask app, and thus to be defined based on run-time settings.