### PR TITLE
Fix flask-restplus required version to 0.11.0 as later one fails validation by `swagger_spec_validator`

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=1.0,<2.0
 
-flask-restplus>=0.11
+flask-restplus==0.11.0
 
 Flask-Cors==3.0.2
 


### PR DESCRIPTION
I'm not sure this is the best fix, but it works